### PR TITLE
Add ability to follow symlinks on Windows Machines

### DIFF
--- a/ejs-middleware.js
+++ b/ejs-middleware.js
@@ -15,7 +15,7 @@ module.exports = function(dir, extension, registerInApp) {
 
         fs.lstat(pathname, function(err, stats) {
             // Requests that match /dir will be interpreted as /dir/index
-            if(!err && stats.isDirectory()) {
+            if(!err && (stats.isDirectory() || (stats.isSymbolicLink() && fs.existsSync(path.join(pathname, 'index'))))) {
                 pathname = path.join(pathname, 'index');
             }
             pathname += '.' + extension;

--- a/ejs-middleware.js
+++ b/ejs-middleware.js
@@ -15,7 +15,7 @@ module.exports = function(dir, extension, registerInApp) {
 
         fs.lstat(pathname, function(err, stats) {
             // Requests that match /dir will be interpreted as /dir/index
-            if(!err && (stats.isDirectory() || (stats.isSymbolicLink() && fs.existsSync(path.join(pathname, 'index'))))) {
+            if(!err && (stats.isDirectory() || (stats.isSymbolicLink() && fs.existsSync(path.join(pathname, 'index') + '.' + extension)))) {
                 pathname = path.join(pathname, 'index');
             }
             pathname += '.' + extension;


### PR DESCRIPTION
For when you have a symlink which points to a folder containing an "index.ejs". 

On Windows, `stats.isDirectory()`, returns false for a symlink directory.
